### PR TITLE
Important! Refactor TodosRepository

### DIFF
--- a/src/__tests__/lambdas/createTodo.test.ts
+++ b/src/__tests__/lambdas/createTodo.test.ts
@@ -34,7 +34,9 @@ describe('createHandler({todosRepository})(event)', () => {
 
         it('should call todosRepository.create once with right args', () => {
           expect(todosRepository.create).toBeCalledTimes(1);
-          expect(todosRepository.create).toBeCalledWith(event.arguments.title);
+          expect(todosRepository.create).toBeCalledWith({
+            title: event.arguments.title,
+          });
         });
 
         it('should reject', () => {
@@ -71,7 +73,9 @@ describe('createHandler({todosRepository})(event)', () => {
 
         it('should call todosRepository.create once with right args', () => {
           expect(todosRepository.create).toBeCalledTimes(1);
-          expect(todosRepository.create).toBeCalledWith(event.arguments.title);
+          expect(todosRepository.create).toBeCalledWith({
+            title: event.arguments.title,
+          });
         });
 
         it('should resolve', () => {

--- a/src/__tests__/lambdas/deleteTodo.test.ts
+++ b/src/__tests__/lambdas/deleteTodo.test.ts
@@ -33,7 +33,9 @@ describe('createHandler({todosRepository})(event)', () => {
 
         it('should call todosRepository.delete once with right args', () => {
           expect(todosRepository.delete).toBeCalledTimes(1);
-          expect(todosRepository.delete).toBeCalledWith(event.arguments.id);
+          expect(todosRepository.delete).toBeCalledWith({
+            id: event.arguments.id,
+          });
         });
 
         it('should reject', () => {
@@ -67,7 +69,9 @@ describe('createHandler({todosRepository})(event)', () => {
 
         it('should call todosRepository.delete once with right args', () => {
           expect(todosRepository.delete).toBeCalledTimes(1);
-          expect(todosRepository.delete).toBeCalledWith(event.arguments.id);
+          expect(todosRepository.delete).toBeCalledWith({
+            id: event.arguments.id,
+          });
         });
 
         it('should resolve', () => {

--- a/src/__tests__/lambdas/getTodo.test.ts
+++ b/src/__tests__/lambdas/getTodo.test.ts
@@ -33,7 +33,9 @@ describe('createHandler({todosRepository})(event)', () => {
 
         it('should call todosRepository.get once with right args', () => {
           expect(todosRepository.get).toBeCalledTimes(1);
-          expect(todosRepository.get).toBeCalledWith(event.arguments.id);
+          expect(todosRepository.get).toBeCalledWith({
+            id: event.arguments.id,
+          });
         });
 
         it('should reject', () => {
@@ -67,7 +69,9 @@ describe('createHandler({todosRepository})(event)', () => {
 
         it('should call todosRepository.get once with right args', () => {
           expect(todosRepository.get).toBeCalledTimes(1);
-          expect(todosRepository.get).toBeCalledWith(event.arguments.id);
+          expect(todosRepository.get).toBeCalledWith({
+            id: event.arguments.id,
+          });
         });
 
         it('should resolve', () => {

--- a/src/__tests__/lambdas/updateTodo.test.ts
+++ b/src/__tests__/lambdas/updateTodo.test.ts
@@ -2,7 +2,7 @@ import { AppSyncResolverEvent } from 'aws-lambda';
 import { createHandler } from '../../lambdas/updateTodo';
 
 describe('createHandler({todosRepository})(event)', () => {
-  describe('when event.arguments.id equals "id1", todo.completed equals true and todo.title equals "Go to Cinema"', () => {
+  describe('when event.arguments.id equals "id1", event.arguments.todo.completed equals true and event.arguments.todo.title equals "Go to Cinema"', () => {
     const event = {
       arguments: {
         id: 'id1',
@@ -40,10 +40,11 @@ describe('createHandler({todosRepository})(event)', () => {
 
         it('should call todosRepository.update once with right args', () => {
           expect(todosRepository.update).toBeCalledTimes(1);
-          expect(todosRepository.update).toBeCalledWith(
-            event.arguments.id,
-            event.arguments.todo,
-          );
+          expect(todosRepository.update).toBeCalledWith({
+            id: event.arguments.id,
+            title: event.arguments.todo.title,
+            completed: event.arguments.todo.completed,
+          });
         });
 
         it('should reject', () => {
@@ -79,10 +80,11 @@ describe('createHandler({todosRepository})(event)', () => {
 
         it('should call todosRepository.update once with right args', () => {
           expect(todosRepository.update).toBeCalledTimes(1);
-          expect(todosRepository.update).toBeCalledWith(
-            event.arguments.id,
-            event.arguments.todo,
-          );
+          expect(todosRepository.update).toBeCalledWith({
+            id: event.arguments.id,
+            title: event.arguments.todo.title,
+            completed: event.arguments.todo.completed,
+          });
         });
 
         it('should resolve', () => {

--- a/src/__tests__/repositories/TodosRepository.test.ts
+++ b/src/__tests__/repositories/TodosRepository.test.ts
@@ -1,6 +1,5 @@
 import { DocumentClient } from 'aws-sdk/clients/dynamodb';
 import TodosRepository from '../../repositories/TodosRepository';
-import { Todo } from '../../types';
 
 jest.spyOn(Date, 'now').mockImplementation(() => 123);
 
@@ -929,15 +928,10 @@ describe('TodosRepository(db,tableName,uuid)', () => {
   });
 
   describe('update(id,todo)', () => {
-    describe('when id equals id007 and todo is passed', () => {
+    describe('when id equals id007 and completed equals true and title equals "Go to school"', () => {
       const id = 'id007';
-      const todo: Todo = {
-        id,
-        completed: true,
-        title: 'Go to shcool',
-        createdAt: 1617716035000,
-        updatedAt: 1617716035000,
-      };
+      const completed = true;
+      const title = 'Go to school';
 
       describe('when tableName equals todos-dev db.update rejects', () => {
         const tableName = 'todos-dev';
@@ -961,10 +955,11 @@ describe('TodosRepository(db,tableName,uuid)', () => {
           beforeEach(async () => {
             try {
               // test
-              await new TodosRepository(db, tableName, jest.fn()).update(
+              await new TodosRepository(db, tableName, jest.fn()).update({
                 id,
-                todo,
-              );
+                title,
+                completed,
+              });
             } catch (e) {
               result = e;
             }
@@ -992,8 +987,8 @@ describe('TodosRepository(db,tableName,uuid)', () => {
                 '#updatedAt': 'updatedAt',
               },
               ExpressionAttributeValues: {
-                ':title': todo.title,
-                ':completed': todo.completed,
+                ':title': title,
+                ':completed': completed,
                 ':now': 123,
               },
             });
@@ -1011,7 +1006,9 @@ describe('TodosRepository(db,tableName,uuid)', () => {
         let promise;
         const updateResponse: DocumentClient.UpdateItemOutput = {
           Attributes: {
-            ...todo,
+            id,
+            title,
+            completed,
             updatedAt: 123,
           },
         };
@@ -1036,7 +1033,7 @@ describe('TodosRepository(db,tableName,uuid)', () => {
                 db,
                 tableName,
                 jest.fn(),
-              ).update(id, todo);
+              ).update({ id, title, completed });
             } catch (e) {}
           });
 
@@ -1062,8 +1059,8 @@ describe('TodosRepository(db,tableName,uuid)', () => {
                 '#updatedAt': 'updatedAt',
               },
               ExpressionAttributeValues: {
-                ':title': todo.title,
-                ':completed': todo.completed,
+                ':title': title,
+                ':completed': completed,
                 ':now': 123,
               },
             });

--- a/src/__tests__/repositories/TodosRepository.test.ts
+++ b/src/__tests__/repositories/TodosRepository.test.ts
@@ -4,7 +4,7 @@ import TodosRepository from '../../repositories/TodosRepository';
 jest.spyOn(Date, 'now').mockImplementation(() => 123);
 
 describe('TodosRepository(db,tableName,uuid)', () => {
-  describe('create(title)', () => {
+  describe('create({title})', () => {
     describe('when title is an empty string', () => {
       const title = '';
       describe('run', () => {
@@ -159,7 +159,7 @@ describe('TodosRepository(db,tableName,uuid)', () => {
     });
   });
 
-  describe('delete(id)', () => {
+  describe('delete({ id })', () => {
     describe('when id equals id007', () => {
       const id = 'id007';
       describe('when tableName equals todos-dev and db.delete rejects', () => {
@@ -273,7 +273,7 @@ describe('TodosRepository(db,tableName,uuid)', () => {
     });
   });
 
-  describe('get(id)', () => {
+  describe('get({id})', () => {
     describe('when id equals id007', () => {
       const id = 'id007';
       describe('when tableName equals todos-dev and db.get rejects', () => {
@@ -296,7 +296,7 @@ describe('TodosRepository(db,tableName,uuid)', () => {
           beforeEach(async () => {
             try {
               // test
-              await new TodosRepository(db, tableName, jest.fn()).get(id);
+              await new TodosRepository(db, tableName, jest.fn()).get({ id });
             } catch (e) {
               result = e;
             }
@@ -345,7 +345,7 @@ describe('TodosRepository(db,tableName,uuid)', () => {
           beforeEach(async () => {
             try {
               // test
-              await new TodosRepository(db, tableName, jest.fn()).get(id);
+              await new TodosRepository(db, tableName, jest.fn()).get({ id });
             } catch (e) {
               result = e;
             }
@@ -399,9 +399,9 @@ describe('TodosRepository(db,tableName,uuid)', () => {
           beforeEach(async () => {
             try {
               // test
-              result = await new TodosRepository(db, tableName, jest.fn()).get(
+              result = await new TodosRepository(db, tableName, jest.fn()).get({
                 id,
-              );
+              });
             } catch (e) {}
           });
 
@@ -929,7 +929,7 @@ describe('TodosRepository(db,tableName,uuid)', () => {
     });
   });
 
-  describe('update(id,todo)', () => {
+  describe('update({id,title,completed})', () => {
     describe('when id equals id007 and completed equals true and title equals "Go to school"', () => {
       const id = 'id007';
       const completed = true;

--- a/src/__tests__/repositories/TodosRepository.test.ts
+++ b/src/__tests__/repositories/TodosRepository.test.ts
@@ -182,7 +182,9 @@ describe('TodosRepository(db,tableName,uuid)', () => {
           beforeEach(async () => {
             try {
               // test
-              await new TodosRepository(db, tableName, jest.fn()).delete(id);
+              await new TodosRepository(db, tableName, jest.fn()).delete({
+                id,
+              });
             } catch (e) {
               result = e;
             }
@@ -241,7 +243,7 @@ describe('TodosRepository(db,tableName,uuid)', () => {
                 db,
                 tableName,
                 jest.fn(),
-              ).delete(id);
+              ).delete({ id });
             } catch (e) {
               result = e;
             }

--- a/src/__tests__/repositories/TodosRepository.test.ts
+++ b/src/__tests__/repositories/TodosRepository.test.ts
@@ -22,7 +22,7 @@ describe('TodosRepository(db,tableName,uuid)', () => {
               jest.fn(),
             );
             // test
-            await instance.create(title);
+            await instance.create({ title });
           } catch (e) {
             result = e;
           }
@@ -59,7 +59,9 @@ describe('TodosRepository(db,tableName,uuid)', () => {
             beforeEach(async () => {
               try {
                 // test
-                await new TodosRepository(db, tableName, uuid).create(title);
+                await new TodosRepository(db, tableName, uuid).create({
+                  title,
+                });
               } catch (e) {
                 result = e;
               }
@@ -119,9 +121,9 @@ describe('TodosRepository(db,tableName,uuid)', () => {
             beforeEach(async () => {
               try {
                 // test
-                result = await new TodosRepository(db, tableName, uuid).create(
+                result = await new TodosRepository(db, tableName, uuid).create({
                   title,
-                );
+                });
               } catch (e) {}
             });
             it('should call uuid once with right args', () => {

--- a/src/lambdas/createTodo.ts
+++ b/src/lambdas/createTodo.ts
@@ -10,7 +10,8 @@ export const createHandler = ({
 }) => async (
   event: AppSyncResolverEvent<CreateTodoArguments>,
 ): Promise<Todo> => {
-  return todosRepository.create(event.arguments.title);
+  const { title } = event.arguments;
+  return todosRepository.create({ title });
 };
 
 export const handler = createHandler({

--- a/src/lambdas/deleteTodo.ts
+++ b/src/lambdas/deleteTodo.ts
@@ -7,8 +7,11 @@ export const createHandler = ({
   todosRepository,
 }: {
   todosRepository: TodosRepository;
-}) => async (event: AppSyncResolverEvent<DeleteTodoArguments>): Promise<Todo> => {
-  return todosRepository.delete(event.arguments.id);
+}) => async (
+  event: AppSyncResolverEvent<DeleteTodoArguments>,
+): Promise<Todo> => {
+  const { id } = event.arguments;
+  return todosRepository.delete({ id });
 };
 
 export const handler = createHandler({

--- a/src/lambdas/getTodo.ts
+++ b/src/lambdas/getTodo.ts
@@ -8,7 +8,8 @@ export const createHandler = ({
 }: {
   todosRepository: TodosRepository;
 }) => async (event: AppSyncResolverEvent<GetTodoArguments>): Promise<Todo> => {
-  return todosRepository.get(event.arguments.id);
+  const { id } = event.arguments;
+  return todosRepository.get({ id });
 };
 
 export const handler = createHandler({

--- a/src/lambdas/updateTodo.ts
+++ b/src/lambdas/updateTodo.ts
@@ -11,7 +11,8 @@ export const createHandler = ({
   event: AppSyncResolverEvent<UpdateTodoArguments>,
 ): Promise<Todo> => {
   const { id, todo } = event.arguments;
-  return todosRepository.update(id, {
+  return todosRepository.update({
+    id,
     title: todo.title,
     completed: todo.completed,
   });

--- a/src/repositories/ITodosRepository.ts
+++ b/src/repositories/ITodosRepository.ts
@@ -1,7 +1,7 @@
 import { Todo, Todos } from '../types';
 
 export default interface ITodosRepository {
-  create(title: string): Promise<Todo>;
+  create({ title }: { title: string }): Promise<Todo>;
   update(
     id: string,
     todo: { title: string; completed: boolean },

--- a/src/repositories/ITodosRepository.ts
+++ b/src/repositories/ITodosRepository.ts
@@ -2,10 +2,15 @@ import { Todo, Todos } from '../types';
 
 export default interface ITodosRepository {
   create({ title }: { title: string }): Promise<Todo>;
-  update(
-    id: string,
-    todo: { title: string; completed: boolean },
-  ): Promise<Todo>;
+  update({
+    id,
+    title,
+    completed,
+  }: {
+    id: string;
+    title: string;
+    completed: boolean;
+  }): Promise<Todo>;
   delete(id: string): Promise<Todo>;
   get(id: string): Promise<Todo>;
   getAll({ limit, token }: { limit?: number; token?: string }): Promise<Todos>;

--- a/src/repositories/ITodosRepository.ts
+++ b/src/repositories/ITodosRepository.ts
@@ -11,7 +11,7 @@ export default interface ITodosRepository {
     title: string;
     completed: boolean;
   }): Promise<Todo>;
-  delete(id: string): Promise<Todo>;
+  delete({ id }: { id: string }): Promise<Todo>;
   get(id: string): Promise<Todo>;
   getAll({ limit, token }: { limit?: number; token?: string }): Promise<Todos>;
 }

--- a/src/repositories/ITodosRepository.ts
+++ b/src/repositories/ITodosRepository.ts
@@ -12,6 +12,6 @@ export default interface ITodosRepository {
     completed: boolean;
   }): Promise<Todo>;
   delete({ id }: { id: string }): Promise<Todo>;
-  get(id: string): Promise<Todo>;
+  get({ id }: { id: string }): Promise<Todo>;
   getAll({ limit, token }: { limit?: number; token?: string }): Promise<Todos>;
 }

--- a/src/repositories/TodosRepository.ts
+++ b/src/repositories/TodosRepository.ts
@@ -67,7 +67,7 @@ export default class TodosRepository implements ITodosRepository {
     return resposne.Attributes as Todo;
   }
 
-  async delete(id: string): Promise<Todo> {
+  async delete({ id }: { id: string }): Promise<Todo> {
     const response = await this.db
       .delete({
         TableName: this.tableName,

--- a/src/repositories/TodosRepository.ts
+++ b/src/repositories/TodosRepository.ts
@@ -33,10 +33,15 @@ export default class TodosRepository implements ITodosRepository {
     return newTodo;
   }
 
-  async update(
-    id: string,
-    todo: { title: string; completed: boolean },
-  ): Promise<Todo> {
+  async update({
+    id,
+    title,
+    completed,
+  }: {
+    id: string;
+    title: string;
+    completed: boolean;
+  }): Promise<Todo> {
     const resposne = await this.db
       .update({
         TableName: this.tableName,
@@ -53,8 +58,8 @@ export default class TodosRepository implements ITodosRepository {
           '#updatedAt': 'updatedAt',
         },
         ExpressionAttributeValues: {
-          ':title': todo.title,
-          ':completed': todo.completed,
+          ':title': title,
+          ':completed': completed,
           ':now': Date.now(),
         },
       })

--- a/src/repositories/TodosRepository.ts
+++ b/src/repositories/TodosRepository.ts
@@ -80,7 +80,7 @@ export default class TodosRepository implements ITodosRepository {
     return response.Attributes as Todo;
   }
 
-  async get(id: string): Promise<Todo> {
+  async get({ id }: { id: string }): Promise<Todo> {
     const response = await this.db
       .get({
         TableName: this.tableName,

--- a/src/repositories/TodosRepository.ts
+++ b/src/repositories/TodosRepository.ts
@@ -9,7 +9,7 @@ export default class TodosRepository implements ITodosRepository {
     private uuid: () => string,
   ) {}
 
-  async create(title: string): Promise<Todo> {
+  async create({ title }: { title: string }): Promise<Todo> {
     if (!title) {
       throw new Error('title is missing');
     }


### PR DESCRIPTION
I changed the arguments signatures of all the TodosRepository functions as follows:
```
// before
get(id)
create(title)
delete(id)
update(id,{title,completed})

// after
get({id}) 
create({title})
delete({id})
update({id,title,completed})
```
Reasons:
1. I was influenced first by Graphql schema mutations and queries arguments which are good for Graphql definition but I really like functions in javascript to always have an object as 1st argument, because in my experience sometimes we need to add more parameters to the function and I think that it's always better to add multiple parameters in the same object in the 1st argument is always better than adding multiple arguments, it's better in refactoring and maintaining code in javascript in my opinion.
2. I really wanted to make this change in purpose to test the configuration of lint and husky hook "pre-commit" and it helps a lot in refactoring existing code, typescript really helps especially the command `yarn types` to check functions calls.